### PR TITLE
add handling of retel originated auth trunk for 095, and improve logging

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
      "RETELL_SIP_CLIENT_USERNAME": {
       "description": "The name of the Client you configured in jambonz for Retell",
       "type": "string",
-      "required": true
+      "required": false
     },
      "PSTN_TRUNK_NAME": {
       "description": "The name of the Carrier you configured in jambonz towards your SIP service provider",

--- a/lib/routes/retell.js
+++ b/lib/routes/retell.js
@@ -16,20 +16,35 @@ const service = ({logger, makeService}) => {
     sessions[session.call_sid] = session;
     session.locals = {logger: logger.child({call_sid: session.call_sid})};
     let {from, to, direction, call_sid} = session;
-    logger.info(`new incoming call: ${session.call_sid}`);
-
+    logger.info(`new incoming call_sid: ${session.call_sid}`);
+    
     let outboundFromRetell = false;
     if (session.direction === 'inbound' &&
       session.env.PSTN_TRUNK_NAME && session.env.RETELL_SIP_CLIENT_USERNAME &&
       session.sip.headers['X-Authenticated-User']) {
-
       /* check if the call is coming from Retell; i.e. using the sip credential we provisioned there */
       const username = session.sip.headers['X-Authenticated-User'].split('@')[0];
       if (username === session.env.RETELL_SIP_CLIENT_USERNAME) {
-        logger.info(`call ${session.call_sid} is coming from Retell`);
+        logger.info(`call ${session.call_sid} is coming from Retell Client ${username}`);
         outboundFromRetell = true;
       }
     }
+      /* Since 0.9.5 Retell could be an auth trunk */
+    else if (session.direction === 'inbound' && session.env.RETELL_TRUNK_NAME) {
+      if (session.originating_sip_trunk_name === session.env.RETELL_TRUNK_NAME) {
+          logger.info(`call ${session.call_sid} is coming from Retell Trunk ${session.originating_sip_trunk_name}`);
+          outboundFromRetell = true;
+      }
+    }
+
+    if (!outboundFromRetell){
+      logger.info(`call ${session.call_sid} is coming from PSTN Trunk ${session.originating_sip_trunk_name} `);
+    }
+       
+    
+
+
+
     session
       .on('/refer', onRefer.bind(null, session))
       .on('close', onClose.bind(null, session))
@@ -87,6 +102,7 @@ const service = ({logger, makeService}) => {
         })
         .hangup()
         .send();
+      logger.info(target, `Dialling ${session.call_sid} to target`)
     } catch (err) {
       session.locals.logger.info({err}, `Error to responding to incoming call: ${session.call_sid}`);
       session.close();


### PR DESCRIPTION
the client name is now optional as with 0.9.5 retell could be an auth trunk, also improved the logging to be a little more verbose for diags without filling up logs